### PR TITLE
fix: use kustomize overlay for PVC patch in e2e tests

### DIFF
--- a/config/e2e/kustomization.yaml
+++ b/config/e2e/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: flux-system
+
+resources:
+- ../default
+
+patches:
+- path: manager-pvc-patch.yaml
+  target:
+    kind: StatefulSet
+    name: controller-manager
+

--- a/config/e2e/manager-pvc-patch.yaml
+++ b/config/e2e/manager-pvc-patch.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: controller-manager
+spec:
+  volumeClaimTemplates:
+  - metadata:
+      name: artifact-storage
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 10Gi
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: STORAGE_BACKEND
+          value: "pvc"
+        - name: PVC_STORAGE_PATH
+          value: "/data/artifacts"
+        volumeMounts:
+        - name: artifact-storage
+          mountPath: /data/artifacts
+
+
+
+
+


### PR DESCRIPTION
- Create e2e-specific kustomize overlay that includes PVC patch
- Remove patching logic from e2e test (StatefulSet volumeClaimTemplates is immutable)
- Use modern patches syntax with target selector instead of deprecated patchesStrategicMerge
- Fixes 'Not found: artifact-storage' error in BeforeSuite